### PR TITLE
Align lazy.nvim instructions with upstream style

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@
 [lazy.nvim:](https://github.com/folke/lazy.nvim)
 
 ```lua
-{
-  "oskarnurm/koda.nvim",
-  lazy = false, -- make sure we load this during startup if it is your main colorscheme
-  priority = 1000, -- make sure to load this before all the other start plugins
-  config = function()
-    -- require("koda").setup({ transparent = true })
-    vim.cmd("colorscheme koda")
-  end,
+return {
+  { "oskarnurm/koda.nvim", opts = {
+    transparent = true,
+  } },
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "koda",
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
Hi there,

Thanks for this theme, I'm giving it a whirl for the next few days. I've noticed that the LazyVim instructions could be slightly improved to be more idiomatic with LazyVim's plugin system. I've tried to maintain compatibility with the existing code's intentions, but have left out priority and lazy control since I don't think that's necessary.