### PR TITLE
fix: guard vim.pack access to prevent crash on Neovim stable

### DIFF
--- a/lua/koda/groups/init.lua
+++ b/lua/koda/groups/init.lua
@@ -60,8 +60,15 @@ function M.setup(colors, opts)
       end
     end
     -- vim.pack
-    local ok, packdata = pcall(vim.pack.get)
-    if ok and packdata then
+    local packdata
+    if vim.pack then
+      local ok, data = pcall(vim.pack.get)
+      if ok then
+        packdata = data
+      end
+    end
+
+    if packdata then
       for _, plugin in ipairs(packdata) do
         if plugin.active and M.plugins[plugin.spec.name] then
           groups[M.plugins[plugin.spec.name]] = true


### PR DESCRIPTION
This PR guards access to `vim.pack` before calling `vim.pack.get`.
`vim.pack` is currently nightly-only. The current code uses `pcall(vim.pack.get)`, but `vim.pack` is indexed before `pcall` runs, which causes a startup crash on stable Neovim 0.11.5 where `vim.pack` is `nil`.

**Changes**
- Check that `vim.pack` exists before calling `vim.pack.get`
- No behavior change on nightly Neovim
- Prevents hard crash on stable Neovim

**Testing**
- Neovim stable: crash resolved
- Neovim nightly: behavior unchanged. `vim.pack` still detected correctly

Fixes #31 
