### PR TITLE
feat: enable plugin detection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ vim.cmd("colorscheme koda")
 require("koda").setup({
     transparent = false, -- enable for transparent backgrounds
 
-    -- Automatically enable highlights for plugins installed by your plugin manager
+    -- Automatically enable highlights only for plugins installed by your plugin manager
     -- Currently only supports `lazy.nvim` and `vim.pack`
-    -- Default set to `false` because vim.pack can introduce breaking changes
-    auto = false,
+    -- Disable this to load ALL available plugin highlights
+    auto = true,
 
     cache = true, -- cache for better performance
 
@@ -129,6 +129,7 @@ require("koda").setup({
     -- You can modify or extend highlight groups using the `on_highlights` configuration option
     -- Any changes made take effect when highlights are applied
     on_highlights = function(hl, c) end,
+
 })
 
 ````

--- a/lua/koda/config.lua
+++ b/lua/koda/config.lua
@@ -11,7 +11,7 @@ M.defaults = {
     constants = {},
   },
   colors = {},
-  auto = false,
+  auto = true,
   cache = true,
 
   on_highlights = function(highlights, colors) end,


### PR DESCRIPTION
Even if enabling it might mean more breaking changes to users, at least this way, I can become aware of such issues.