### PR TITLE
feat: add get_palette() API for accessing colors

### DIFF
--- a/lua/koda/init.lua
+++ b/lua/koda/init.lua
@@ -10,6 +10,20 @@ function M.setup(opts)
   end, {})
 end
 
+--- Get the current palette with any user overrides applied
+---@return koda.Palette
+function M.get_palette()
+  local config = require("koda.config")
+  local palette = require("koda.palette." .. vim.o.background)
+
+  -- Apply custom color overrides if they exist
+  if config.options.colors and type(config.options.colors) == "table" then
+    palette = vim.tbl_deep_extend("force", palette, config.options.colors)
+  end
+
+  return palette
+end
+
 -- TODO: look into a better solution
 -- Reload the colorscheme when the background changes
 -- HACK: we keep track of 'old_bg' and 'new_bg' to prevent the colorscheme reloading twice during startup


### PR DESCRIPTION
## Summary

Adds a `get_palette()` function to access the color palette with user overrides applied, similar to catppuccin's `get_palette()` API.

## Motivation

This allows users to reference koda colors in other plugin configurations, set custom highlght groups, etc.

## Usage
```lua
local koda = require("koda").get_palette()
-- Use koda.green, koda.danger, etc.
```

## Testing

Tested locally (manually) with custom color overrides - palette correctly reflects both base colors and user overrides.