### PR TITLE
feat(extras): add lazygit light and dark theme

### DIFF
--- a/extras/lazygit/koda-dark.yml
+++ b/extras/lazygit/koda-dark.yml
@@ -1,0 +1,24 @@
+gui:
+  theme:
+    activeBorderColor:
+      - '#d9ba73'
+      - bold
+    inactiveBorderColor:
+      - '#777777'
+    optionsTextColor:
+      - '#8ebeec'
+    selectedLineBgColor:
+      - '#272727'
+    cherryPickedCommitBgColor:
+      - '#272727'
+    cherryPickedCommitFgColor:
+      - '#f2a4db'
+    unstagedChangesColor:
+      - '#ff7676'
+    defaultFgColor:
+      - '#b0b0b0'
+    searchingActiveBorderColor:
+      - '#ff5733'
+
+  authorColors:
+    '*': '#ffffff'

--- a/extras/lazygit/koda-light.yml
+++ b/extras/lazygit/koda-light.yml
@@ -1,0 +1,24 @@
+gui:
+  theme:
+    activeBorderColor:
+      - '#b07700'
+      - bold
+    inactiveBorderColor:
+      - '#969ba5'
+    optionsTextColor:
+      - '#0253be'
+    selectedLineBgColor:
+      - '#ebebeb'
+    cherryPickedCommitBgColor:
+      - '#ebebeb'
+    cherryPickedCommitFgColor:
+      - '#c301fb'
+    unstagedChangesColor:
+      - '#ca0043'
+    defaultFgColor:
+      - '#101010'
+    searchingActiveBorderColor:
+      - '#f30052'
+
+  authorColors:
+    '*': '#101010'


### PR DESCRIPTION
Note: as seen in the screenshots below, there's quite a lot of color. I tried to reduce color usage as best as I could, but it seems like LazyGit wants to put colors all over the place.

If there's too much color here, please feel free to request changes or close it entirely. I'm not all that happy with this as it currently stands.

<img width="1066" height="773" alt="image" src="https://github.com/user-attachments/assets/5f42979a-8fe3-46d3-81d8-f8b2155e455f" />
<img width="1066" height="773" alt="image" src="https://github.com/user-attachments/assets/62d974c9-8f61-4774-86ce-2306e8c60372" />
