### PR TITLE
feat(lsp): highlight semantic types more granularly

### DIFF
--- a/lua/koda/groups/lsp.lua
+++ b/lua/koda/groups/lsp.lua
@@ -5,16 +5,26 @@ local M = {}
 function M.get_hl(c)
   -- stylua: ignore
   return {
-    DiagnosticError                       = { fg = c.danger },
-    DiagnosticHint                        = { fg = c.info },
-    DiagnosticInfo                        = { fg = c.fg },
-    DiagnosticOK                          = { fg = c.success },
-    DiagnosticWarn                        = { fg = c.warning },
-    LspInlayHint                          = { fg = c.comment },
-    ["@lsp.type.comment"]                 = {}, -- use treesitter styles
-    ["@lsp.type.lifetime"]                = { fg = c.const },
-    ["@lsp.type.modifier"]                = { fg = c.keyword },
-    ["@lsp.typemod.namespace.attribute"]  = { fg = c.keyword },
+    DiagnosticError                        = { fg = c.danger },
+    DiagnosticHint                         = { fg = c.info },
+    DiagnosticInfo                         = { fg = c.fg },
+    DiagnosticOK                           = { fg = c.success },
+    DiagnosticWarn                         = { fg = c.warning },
+    LspInlayHint                           = { fg = c.comment },
+    ["@lsp.type.comment"]                  = {}, -- use treesitter styles
+    ["@lsp.type.lifetime"]                 = { fg = c.const },
+    ["@lsp.type.modifier"]                 = { link = "Keyword" },
+    ["@lsp.type.struct"]                   = { link = "Normal" },
+    ["@lsp.typemod.namespace.attribute"]   = { link = "Keyword" },
+    ["@lsp.typemod.interface.declaration"] = { link = "Normal" },
+    ["@lsp.typemod.interface.public"]      = { link = "Normal" },
+    ["@lsp.typemod.struct.declaration"]    = { link = "Normal" },
+    ["@lsp.typemod.enum.declaration"]      = { link = "Normal" },
+    ["@lsp.typemod.type.declaration"]      = { link = "Normal" },
+    ["@lsp.typemod.class.declaration"]     = { link = "Normal" },
+    ["@lsp.typemod.class.globalScope"]     = { link = "Normal" },
+    ["@lsp.typemod.generic.attribute"]     = { link = "Normal" },
+    -- ["@lsp.type.namespace"]                = { fg = c.keyword },
   }
 end
 

--- a/lua/koda/groups/treesitter.lua
+++ b/lua/koda/groups/treesitter.lua
@@ -29,7 +29,7 @@ function M.get_hl(c, opts)
     ["@boolean"]                       = { link = "Boolean" },
     ["@number"]                        = { link = "Number" },
     ["@number.float"]                  = { link = "Number" },
-    ["@type"]                          = { link = "Identifier" },
+    ["@type"]                          = { link = "Type" },
     ["@type.builtin"]                  = { link = "Type" },
     ["@type.definition"]               = { link = "Identifier" },
     ["@attribute"]                     = { link = "Keyword" },


### PR DESCRIPTION
We want types to stand out more. How can we do that without adding more color? This is my attempt at it. Not sure what the mileage on this will be. 