### PR TITLE
fix: change CursorColumn bg to use line color

### DIFF
--- a/lua/koda/groups/base.lua
+++ b/lua/koda/groups/base.lua
@@ -14,7 +14,7 @@ function M.get_hl(c, opts)
     TermCursor        = { link = "Cursor" },
     lCursor           = { link = "Cursor" },
     CursorIM          = { link = "Cursor" },
-    CursorColumn      = { link = "Cursor" },
+    CursorColumn      = { bg = c.line },
     CursorLine        = { bg = c.line },
     ColorColumn       = { bg = c.line },
     CursorLineNr      = { fg = c.border, bold = true },


### PR DESCRIPTION
Fixes the vertical CursorColumn background to match the e.g. CursorLine background.

Before:
<img width="430" height="229" alt="image" src="https://github.com/user-attachments/assets/c9c068ab-3e7e-47c9-a6a5-4e7ef0bf57df" />

After:
<img width="430" height="229" alt="image" src="https://github.com/user-attachments/assets/eea1f9d6-b8f3-46b1-9196-3cb3348aeacb" />
