### PR TITLE
fix(mini): detect individual mini.* modules for group activation

### DIFF
--- a/lua/koda/groups/init.lua
+++ b/lua/koda/groups/init.lua
@@ -76,7 +76,7 @@ function M.setup(colors, opts)
             groups[M.plugins[plugin.spec.name]] = true
           end
           -- Special case: detect individual mini.* modules
-          if plugin.active and plugin.spec.name:match("^mini%.") then
+          if not groups.mini and plugin.active and plugin.spec.name:match("^mini%.") then
             groups.mini = true
           end
         end


### PR DESCRIPTION
## Problem

The mini group was only activated when `mini.nvim` (the monolithic package) was detected. Users who install individual mini.nvim modules (`mini.pick`, `mini.icons`, `mini.files`, etc.) didn't get mini highlights applied.

## Solution

Added special case detection for any plugin matching the `mini.*` pattern in both lazy.nvim and vim.pack detection paths.