### PR TITLE
refactor(mini): update icon color mappings for better semantic clarity

### DIFF
--- a/lua/koda/groups/mini.lua
+++ b/lua/koda/groups/mini.lua
@@ -13,7 +13,7 @@ function M.get_hl(c)
     MiniIconsCyan             = { fg = c.info },
     MiniIconsGreen            = { fg = c.success },
     MiniIconsOrange           = { fg = c.warning },
-    MiniIconsPurple           = { fg = c.pink },
+    MiniIconsPurple           = { fg = c.orange },
     MiniIconsRed              = { fg = c.danger },
     MiniIconsYellow           = { fg = c.const },
   }


### PR DESCRIPTION
The mini.nvim icon colors were too intense and pulled focus unnecessarily. I've adjusted them to be more subtle while maintaining distinction.

I considered reducing to 2-3 colors (const, white, gray) to match semantic highlighting, but that felt too drastic. Let me know your thoughts.

Please note that this is totally subjective, so please feel free to make suggestions if you dislike it or want to stick with the original colors.

**Changes:**
  - Blue: `highlight` → `fg`
  - Green: `green` → `success`
  - Orange: `highlight` → `warning`
  - Purple: `orange` → `pink`
  - Red: `red` → `danger`

The below images are from:
- neo-tree with mini.icons (first image)
- mini.pick with mini.extra showing highlight groups (`require('mini.extra').pickers.hl_groups`) (second image)

**Before**
<img width="169" height="233" alt="image" src="https://github.com/user-attachments/assets/62260ba9-7f4f-4a8c-afcd-691d08e0cfbd" />
<img width="169" height="214" alt="image" src="https://github.com/user-attachments/assets/a299a881-c16f-4e79-9a73-30291acd57d6" />


**After**
<img width="169" height="233" alt="image" src="https://github.com/user-attachments/assets/4376e7f7-a286-4a7d-b0d9-275bfe2ac310" />
<img width="169" height="214" alt="image" src="https://github.com/user-attachments/assets/f98800f2-f59a-40e5-99e6-34d8b335e9cc" />