### PR TITLE
feat: add group loading support for plugins loaded with mini.deps

### DIFF
--- a/lua/koda/groups/init.lua
+++ b/lua/koda/groups/init.lua
@@ -69,6 +69,13 @@ function M.setup(colors, opts)
         end
       end
     end
+    if _G.MiniDeps then -- try mini.deps
+      for _, plugin in ipairs(_G.MiniDeps.get_session()) do
+        if M.plugins[plugin.name] then
+          groups[M.plugins[plugin.name]] = true
+        end
+      end
+    end
   end
 
   -- Sort (in-place) group names for consistent cache keys


### PR DESCRIPTION
This PR adds support to load highlight groups for plugins loaded with `mini.deps`.