### PR TITLE
fix: incorrect treesitter markup link and other small fixes

### DIFF
--- a/lua/koda/groups/init.lua
+++ b/lua/koda/groups/init.lua
@@ -46,12 +46,12 @@ function M.setup(colors, opts, theme)
 
   -- Load highlights only for plugins managed by plugin managers
   -- Currently only supports lazy.nvim and vim.pack
-  -- Can set `opts.auto=false` to load all highlights as a fallback
+  -- Setting `opts.auto=false` during setup will load all highlights
   if not opts.auto then
     for _, group in pairs(M.plugins) do
       groups[group] = true
     end
-  elseif opts.auto then
+  else
     if package.loaded.lazy then -- try lazy.nvim
       local lazy_plugins = require("lazy.core.config").plugins
       for plugin, group in pairs(M.plugins) do

--- a/lua/koda/groups/init.lua
+++ b/lua/koda/groups/init.lua
@@ -36,7 +36,7 @@ end
 ---@return koda.Highlights
 ---@return table
 function M.setup(colors, opts, theme)
-  -- Always laod base groups
+  -- Always load base groups
   local groups = {
     base = true,
     syntax = true,

--- a/lua/koda/groups/treesitter.lua
+++ b/lua/koda/groups/treesitter.lua
@@ -83,7 +83,7 @@ function M.get_hl(c)
     ["@markup.quote"]                  = { link = "Comment" },
     ["@markup.math"]                   = { link = "Special" },
     ["@markup.link"]                   = { fg = c.emphasis, underline = true },
-    ["@markup.link.label"]             = { link = "@markup.link.label" },
+    ["@markup.link.label"]             = { fg = c.emphasis, underline = false },
     ["@markup.link.url"]               = { fg = c.info, underline = true },
     ["@markup.raw"]                    = { fg = c.const },
     ["@markup.raw.block"]              = { fg = c.const },

--- a/lua/koda/utils.lua
+++ b/lua/koda/utils.lua
@@ -113,8 +113,8 @@ function M.reload()
 end
 
 --- Resolves the current theme variant based on user config and background settings
---@param theme string|nil
---@return string
+---@param theme string|nil
+---@return string
 function M.resolve(theme)
   if theme then
     return theme

--- a/lua/koda/utils.lua
+++ b/lua/koda/utils.lua
@@ -2,11 +2,14 @@ local M = {}
 
 M.cache = {}
 
---- Reads the given file and returns its contents
+--- Reads a file from disk
 ---@param fname string
----@return string|nil
+---@return string|nil, string|nil
 function M.read(fname)
-  local file = assert(io.open(fname, "r"))
+  local file, err = io.open(fname, "r")
+  if not file then
+    return nil, err
+  end
   local data = file:read("*a")
   file:close()
   return data
@@ -33,8 +36,8 @@ end
 ---@param key string
 ---@return koda.Cache|nil
 function M.cache.read(key)
-  local ok, data = pcall(M.read, M.cache.file(key))
-  if not ok then
+  local data = M.read(M.cache.file(key))
+  if not data then
     return nil
   end
   local is_ok, ret = pcall(vim.json.decode, data, { luanil = { object = true, array = true } })


### PR DESCRIPTION
Fixed:
- small typo
- removed redundant elseif check when lazy loading plugins via package managers in groups/init
- markup.link.label incorrectly linking to itself
- annotations
- removed assert from M.read and refactored it to be more Lua idiomatic with returning nil instead