### PR TITLE
fix(gitsigns): add highlight group for inline blame

### DIFF
--- a/lua/koda/groups/gitsigns.lua
+++ b/lua/koda/groups/gitsigns.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local Utils = require("koda.utils")
+
 ---@type koda.HighlightsFn
 function M.get_hl(c)
   -- stylua: ignore
@@ -9,7 +11,8 @@ function M.get_hl(c)
     GitSignsDelete        = { fg = c.danger },
     GitSignsDeleteInline  = { link = "DiffChange" },
     GitSignsAddInline     = { link = "DiffChange" },
-    GitSignsChangeInLine  = { link = "DiffChange" }
+    GitSignsChangeInLine  = { link = "DiffChange" },
+    GitSignsCurrentLineBlame = { fg = Utils.blend(c.fg, c.line, 0.4) },
   }
 end
 


### PR DESCRIPTION
color was defaulting to the same color as cursorline (c.line), now it's blending c.fg and c.line at 0.4 alpha

can adjust blend at request :-)

<details>
<summary>screenshots</summary>
dark:
<img width="1814" height="245" alt="koda-dark-blame" src="https://github.com/user-attachments/assets/2b93bc04-ba56-4512-a707-64ddda7be747" />

light:
<img width="1764" height="205" alt="koda-light-blame" src="https://github.com/user-attachments/assets/9be56e5e-cf5c-4cce-bd54-890c6be3c80d" />

moss:
<img width="1756" height="213" alt="koda-moss-blame" src="https://github.com/user-attachments/assets/97120a0c-acd6-4d2a-bb78-701ef29c0223" />


glade:
<img width="1749" height="204" alt="koda-glade-blame" src="https://github.com/user-attachments/assets/a371d230-a32b-4a94-9037-62ffd270603a" />
</details>

