### PR TITLE
fix: consistent koda.Highlights type annotation to allow string links

### DIFF
--- a/lua/koda/types.lua
+++ b/lua/koda/types.lua
@@ -1,7 +1,7 @@
 ---@class koda.Highlight: vim.api.keyset.highlight
 ---@field style? vim.api.keyset.highlight
 
----@alias koda.Highlights table<string, koda.Highlight>
+---@alias koda.Highlights table<string, koda.Highlight|string>
 --- Values can be either:
 ---  - koda.Highlight: Full highlight definition with fg, bg, style, etc.
 ---  - string: Link to another highlight group (e.g., "Normal")

--- a/lua/koda/types.lua
+++ b/lua/koda/types.lua
@@ -1,10 +1,10 @@
 ---@class koda.Highlight: vim.api.keyset.highlight
 ---@field style? vim.api.keyset.highlight
 
----@alias koda.Highlights table<string, koda.Highlight|string>
---- Values can be either:
----  - koda.Highlight: Full highlight definition with fg, bg, style, etc.
----  - string: Link to another highlight group (e.g., "Normal")
+---@alias koda.Highlights table<string, koda.Highlight>
+--- Values must be a koda.Highlight table.
+--- To link to another highlight group, use the `link` property:
+--- e.g., { link = "Normal" }
 
 ---@alias koda.HighlightsFn fun(colors: koda.Palette, opts: koda.Config): koda.Highlights
 --- Takes color palette and config, returns highlight definitions


### PR DESCRIPTION
The `koda.Highlights` type alias only allows values of type `koda.Highlight`, but string values (as links to other groups) are also accepted (even mentioned in the comment below). Adding the `|string` union to the annotation makes the type match the runtime behavior.

upd: Great light colorscheme, btw. Using it all the time when ambient is too bright. Cheers