### PR TITLE
fix: background changes update theme variant

### DIFF
--- a/lua/koda/init.lua
+++ b/lua/koda/init.lua
@@ -46,7 +46,7 @@ function M.load(theme)
   if vim.fn.exists("syntax_on") == 1 then
     vim.cmd("syntax reset")
   end
-  vim.g.colors_name = theme and "koda-" .. theme or "koda"
+  vim.g.colors_name = "koda"
 
   -- Unpack and resolve custom styles
   local hl_groups = groups.setup(palette, config.options, theme)

--- a/lua/koda/init.lua
+++ b/lua/koda/init.lua
@@ -36,6 +36,7 @@ end
 
 --- Main function to apply the theme
 function M.load(theme)
+  local name = theme and "koda-" .. theme or "koda"
   theme = require("koda.utils").resolve(theme)
   local config = require("koda.config")
   local groups = require("koda.groups") -- points to lua/koda/groups/init.lua
@@ -46,7 +47,7 @@ function M.load(theme)
   if vim.fn.exists("syntax_on") == 1 then
     vim.cmd("syntax reset")
   end
-  vim.g.colors_name = "koda"
+  vim.g.colors_name = name
 
   -- Unpack and resolve custom styles
   local hl_groups = groups.setup(palette, config.options, theme)

--- a/tests/koda_spec.lua
+++ b/tests/koda_spec.lua
@@ -1,3 +1,4 @@
+local koda = require("koda")
 local config = require("koda.config")
 local utils = require("koda.utils")
 
@@ -28,5 +29,54 @@ describe("Koda Colorscheme", function()
     local exists = vim.uv.fs_stat(cache)
 
     assert.is_truthy(exists, "Cache file was not created at " .. cache)
+  end)
+
+  describe("should automatically switch theme variant on background change", function()
+    local initial_background = vim.o.background
+    after_each(function()
+      vim.o.background = initial_background
+    end)
+
+    local function compare()
+      local expected = koda.get_palette(utils.resolve()).bg
+      -- Format from decimal representation back to RGB hexadecimal (how palettes are represented).
+      local actual = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal" }).bg)
+
+      assert.are_equal(expected, actual, "Background (" .. vim.o.background .. ") values differ theme=" .. expected .. " bg=" .. actual)
+    end
+
+    local function toggle_bg()
+      vim.o.background = vim.o.background == "dark" and "light" or "dark"
+    end
+
+    local cases = {
+      ["default"] = {},
+      ["alternative"] = {
+        theme = {
+          dark = "moss",
+          light = "glade",
+        },
+      },
+      ["always-dark"] = {
+        theme = {
+          dark = "dark",
+          light = "dark",
+        },
+      },
+    }
+
+    for name, cfg in pairs(cases) do
+      config.setup(cfg)
+      utils.reload()
+
+      it(name, function()
+        vim.cmd("colorscheme koda")
+        compare()
+        toggle_bg()
+        compare()
+        toggle_bg()
+        compare()
+      end)
+    end
   end)
 end)


### PR DESCRIPTION
On Gnome + Ghostty or Ptyxis (and most likely all terminals), changing the system's theme variant from light to dark and back reacts everywhere except for nvim when koda is set up with this config:
```lua
-- Taken from the README.
vim.pack.add({ "https://github.com/oskarnurm/koda.nvim" })
vim.cmd("colorscheme koda")
```

I'm guessing [this commit](https://github.com/oskarnurm/koda.nvim/commit/4fe384484afc06140cefe046acb881119c284400#diff-cce65828a281a1244cd4d3180d09454f5a3f7d149826190566bb7b156e2063f3L47-R49) is the reason why this feature broke.
So her are 2 commits:
1. Introduce tests to cover theme variant switching, [which fails as you can see here](https://github.com/vahnrr/koda.nvim/actions/runs/26329225740/job/77512271760) (nvim keeps the dark background `#101010`)
2. Fix this behaviour in koda, [which now works as intended as you can see here](https://github.com/vahnrr/koda.nvim/actions/runs/26329248634/job/77512326736)