### PR TITLE
feat(cache): optimize cache validation and add in-memory caching layer

### DIFF
--- a/lua/koda/groups/init.lua
+++ b/lua/koda/groups/init.lua
@@ -3,6 +3,8 @@ local Config = require("koda.config")
 
 local M = {}
 
+M._mem_cache = {}
+
 -- stylua: ignore
 M.plugins = {
   ["blink.cmp"]                = "blink",
@@ -99,7 +101,6 @@ function M.setup(colors, opts, theme)
   table.sort(names)
 
   local config = {
-    colors = colors,
     plugins = names,
     version = Config._version,
     opts = {
@@ -109,10 +110,35 @@ function M.setup(colors, opts, theme)
     },
   }
 
+  -- Peform lightweight primitive comparisons in an attempt to exit early
+  local function cache_valid(c)
+    return c
+      and c.version == config.version
+      and c.opts.transparent == config.opts.transparent
+      and vim.deep_equal(c.plugins, config.plugins)
+      and vim.deep_equal(c.opts.styles, config.opts.styles)
+      and vim.deep_equal(c.opts.colors, config.opts.colors)
+  end
+
   -- Check if we can use cached highlights
   local cache_key = theme or vim.o.background
-  local cache = opts.cache and Utils.cache.read(cache_key)
-  local hl = cache and vim.deep_equal(config, cache.config) and cache.groups
+  local hl
+
+  -- Check in-memory cache first
+  local mem = M._mem_cache[cache_key]
+  if mem and cache_valid(mem.config) then
+    hl = mem.groups
+  end
+
+  -- Check disk cache if not in memory
+  if not hl then
+    local cache = opts.cache and Utils.cache.read(cache_key)
+    hl = cache and cache_valid(cache.config) and cache.groups
+    if hl then
+      -- Populate in-memory cache
+      M._mem_cache[cache_key] = { groups = hl, config = config }
+    end
+  end
 
   -- Generate highlights if cache miss
   if not hl then
@@ -125,6 +151,7 @@ function M.setup(colors, opts, theme)
     Utils.unpack(hl)
     if opts.cache then
       Utils.cache.write(cache_key, { groups = hl, config = config })
+      M._mem_cache[cache_key] = { groups = hl, config = config }
     end
   end
   opts.on_highlights(hl, colors)


### PR DESCRIPTION
This is an attempt to optimize the caching logic even further:

### Summary of changes:
We no longer serialize or read the 28+ default palette keys to/from the cache file. The metadata should be smaller and cleaner. Instead of diving straight into nested tables, `cache_valid` checks simple primitive fields first (`version` and `transparent`):
- If a `version` mismatch occurs (e.g., you updated koda.nvim), it fails on the first comparison without touching any tables.
- If the `transparency` settings change, it immediately fails on the second comparison.

**Fewer Table Traversals:**
By checking primitive options first and omitting the full palette comparison, the Lua engine only performs table comparisons on the small `plugins`,  `styles`, and `colors` override tables. This should be significantly faster and more resource-efficient.

